### PR TITLE
ci: ruff format チェックを lint パイプラインと CI に追加 (Issue #58)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,3 +36,18 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - run: make setup-dev
       - run: make pylint
+
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Cache venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+      - run: make setup-dev
+      - run: make format-check

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ COMMA := ,
 # Kedro logging configuration (enables [file_id] prefix in logs)
 export KEDRO_LOGGING_CONFIG := $(BASE_DIR)/conf/base/logging.yml
 
-.PHONY: help setup setup-dev test coverage check lint ruff pylint clean
+.PHONY: help setup setup-dev test coverage check lint ruff pylint format format-check clean
 .PHONY: rag-index rag-search rag-ask rag-status
 .PHONY: test-e2e test-e2e-update-golden test-e2e-golden test-clean
 .PHONY: run kedro-run kedro-test kedro-viz
@@ -47,9 +47,11 @@ help:
 	@echo "  test           全テスト実行"
 	@echo "  coverage       テストカバレッジ計測 (≥80%)"
 	@echo "  check          Python構文チェック"
-	@echo "  lint           コード品質チェック (ruff + pylint)"
+	@echo "  lint           コード品質チェック (ruff + pylint + format-check)"
 	@echo "  ruff           ruff リンター実行"
 	@echo "  pylint         pylint リンター実行"
+	@echo "  format-check   ruff フォーマットチェック"
+	@echo "  format         ruff フォーマット適用"
 	@echo ""
 	@echo "File Organization:"
 	@echo "  organize-preview"
@@ -299,8 +301,20 @@ pylint:
 	@$(VENV_DIR)/bin/pylint src/obsidian_etl/
 	@echo "✅ pylint passed"
 
-# コード品質チェック (ruff + pylint, fail-fast)
-lint: ruff pylint
+# フォーマットチェック (ruff format --check)
+format-check:
+	@echo "Running ruff format check..."
+	@$(VENV_DIR)/bin/ruff format --check src/ tests/
+	@echo "✅ ruff format check passed"
+
+# フォーマット適用 (ruff format)
+format:
+	@echo "Running ruff format..."
+	@$(VENV_DIR)/bin/ruff format src/ tests/
+	@echo "✅ ruff format applied"
+
+# コード品質チェック (ruff + pylint + format-check, fail-fast)
+lint: ruff pylint format-check
 	@echo "✅ All linters passed"
 
 # E2Eテスト用データディレクトリ削除

--- a/specs/quick/009-058-lint-ruff-format/plan.md
+++ b/specs/quick/009-058-lint-ruff-format/plan.md
@@ -1,0 +1,64 @@
+---
+status: completed
+created: 2026-03-07
+branch: quick/009-058-lint-ruff-format
+---
+
+# 009-058-lint-ruff-format
+
+## 概要
+
+lint.yml に ruff format チェックを追加し、Makefile に format-check / format ターゲットを追加する。既存コードのフォーマット修正も含む（20ファイル）。
+
+## ゴール
+
+- [x] `make format-check` でフォーマットチェックが通る
+- [x] lint.yml で ruff format が CI 実行される
+- [x] `make test` が引き続き通る
+
+## スコープ外
+
+- mypy の導入（Issue #59）
+- テストワークフロー追加（Issue #57）
+
+## 前提条件
+
+- ruff は既に pyproject.toml に設定済み
+- Makefile に ruff / pylint ターゲットが存在
+- 20ファイルにフォーマット差分あり
+
+---
+
+## 実装タスク
+
+### Phase 1: Makefile 更新
+
+- [x] T001 [Makefile] `format-check` ターゲット追加（ruff format --check src/ tests/）
+- [x] T002 [Makefile] `format` ターゲット追加（ruff format src/ tests/）
+
+### Phase 2: 既存コードのフォーマット
+
+- [x] T003 `make format` で20ファイルをフォーマット
+- [x] T004 `make test` でフォーマット後もテストが通ることを確認
+
+### Phase 3: CI 更新
+
+- [x] T005 [.github/workflows/lint.yml] ruff format チェックステップを追加
+
+---
+
+## リスク
+
+| レベル | 内容 |
+|-------|------|
+| LOW | ruff format はコードの意味を変えない（空白・改行のみ） |
+| LOW | テスト結果に影響なし |
+
+---
+
+## 完了条件
+
+- [x] 全タスク完了（5タスク）
+- [x] `make format-check` が通る
+- [x] `make test` が通る
+- [x] lint.yml に ruff format ステップが追加されている

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -9,6 +9,7 @@ Subcommands:
 - ask: Q&A with LLM
 - status: Show index status
 """
+
 from __future__ import annotations
 
 import argparse
@@ -344,7 +345,9 @@ def _output_index_results(
         print("\nBy Vault:")
         for vault_name, result in results.items():
             status = "OK" if not result.errors else "ERROR"
-            print(f"  {vault_name}: {result.indexed_docs} docs, {result.total_chunks} chunks [{status}]")
+            print(
+                f"  {vault_name}: {result.indexed_docs} docs, {result.total_chunks} chunks [{status}]"
+            )
             for error in result.errors:
                 print(f"    - {error}")
 
@@ -381,10 +384,14 @@ def cmd_search(args: argparse.Namespace) -> int:
         pipeline = create_search_pipeline(store)
 
         # Build filters
-        filters = QueryFilters(
-            vaults=vaults,
-            tags=tags,
-        ) if vaults or tags else None
+        filters = (
+            QueryFilters(
+                vaults=vaults,
+                tags=tags,
+            )
+            if vaults or tags
+            else None
+        )
 
         # Execute search
         start_time = time.time()
@@ -435,7 +442,9 @@ def _output_search_json(response: SearchResponse, elapsed_ms: int) -> None:
                 "title": result.title,
                 "file_path": result.file_path,
                 "vault": result.vault,
-                "snippet": result.content[:200] + "..." if len(result.content) > 200 else result.content,
+                "snippet": result.content[:200] + "..."
+                if len(result.content) > 200
+                else result.content,
             }
             for result in response.results
         ],
@@ -478,10 +487,14 @@ def cmd_ask(args: argparse.Namespace) -> int:
         pipeline = create_qa_pipeline(store)
 
         # Build filters
-        filters = QueryFilters(
-            vaults=vaults,
-            tags=tags,
-        ) if vaults or tags else None
+        filters = (
+            QueryFilters(
+                vaults=vaults,
+                tags=tags,
+            )
+            if vaults or tags
+            else None
+        )
 
         # Execute Q&A
         start_time = time.time()

--- a/src/rag/clients/__init__.py
+++ b/src/rag/clients/__init__.py
@@ -1,6 +1,7 @@
 """
 RAG Clients - Ollama API クライアント
 """
+
 from src.rag.clients.ollama import check_connection, generate_response, get_embedding
 
 __all__ = ["check_connection", "get_embedding", "generate_response"]

--- a/src/rag/clients/ollama.py
+++ b/src/rag/clients/ollama.py
@@ -3,6 +3,7 @@ Ollama Client - Ollama API クライアント
 
 リモート Embedding サーバー (bge-m3) とローカル LLM (gpt-oss:20b) への接続機能を提供
 """
+
 from __future__ import annotations
 
 import json

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -1,6 +1,7 @@
 """
 RAG Configuration - 設定値、定数、パス定義
 """
+
 from __future__ import annotations
 
 import os

--- a/src/rag/exceptions.py
+++ b/src/rag/exceptions.py
@@ -1,6 +1,7 @@
 """
 RAG Exceptions - カスタム例外クラス階層
 """
+
 from __future__ import annotations
 
 

--- a/src/rag/pipelines/__init__.py
+++ b/src/rag/pipelines/__init__.py
@@ -1,6 +1,7 @@
 """
 RAG Pipelines - Indexing & Query Pipelines
 """
+
 from src.rag.pipelines.indexing import (
     Document,
     DocumentMeta,

--- a/src/rag/pipelines/indexing.py
+++ b/src/rag/pipelines/indexing.py
@@ -1,6 +1,7 @@
 """
 Indexing Pipeline - Vault ドキュメントのスキャン・チャンキング・インデックス作成
 """
+
 from __future__ import annotations
 
 import re

--- a/src/rag/pipelines/query.py
+++ b/src/rag/pipelines/query.py
@@ -1,6 +1,7 @@
 """
 Query Pipeline - Semantic search and Q&A functionality
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -114,42 +115,52 @@ def build_qdrant_filters(filters: QueryFilters | None) -> dict[str, Any] | None:
     # Vault filter
     if filters.vaults:
         if len(filters.vaults) == 1:
-            conditions.append({
-                "field": "meta.vault",
-                "operator": "==",
-                "value": filters.vaults[0],
-            })
+            conditions.append(
+                {
+                    "field": "meta.vault",
+                    "operator": "==",
+                    "value": filters.vaults[0],
+                }
+            )
         else:
-            conditions.append({
-                "field": "meta.vault",
-                "operator": "in",
-                "value": filters.vaults,
-            })
+            conditions.append(
+                {
+                    "field": "meta.vault",
+                    "operator": "in",
+                    "value": filters.vaults,
+                }
+            )
 
     # Tags filter (AND - all tags must match)
     if filters.tags:
         for tag in filters.tags:
-            conditions.append({
-                "field": "meta.tags",
-                "operator": "contains",
-                "value": tag,
-            })
+            conditions.append(
+                {
+                    "field": "meta.tags",
+                    "operator": "contains",
+                    "value": tag,
+                }
+            )
 
     # Date from filter
     if filters.date_from:
-        conditions.append({
-            "field": "meta.created",
-            "operator": ">=",
-            "value": filters.date_from.isoformat(),
-        })
+        conditions.append(
+            {
+                "field": "meta.created",
+                "operator": ">=",
+                "value": filters.date_from.isoformat(),
+            }
+        )
 
     # Date to filter
     if filters.date_to:
-        conditions.append({
-            "field": "meta.created",
-            "operator": "<=",
-            "value": filters.date_to.isoformat(),
-        })
+        conditions.append(
+            {
+                "field": "meta.created",
+                "operator": "<=",
+                "value": filters.date_to.isoformat(),
+            }
+        )
 
     if not conditions:
         return None
@@ -254,10 +265,12 @@ def search(
         qdrant_filters = build_qdrant_filters(filters)
 
         # Run pipeline
-        result = pipeline.run({
-            "embedder": {"text": query},
-            "retriever": {"top_k": top_k, "filters": qdrant_filters},
-        })
+        result = pipeline.run(
+            {
+                "embedder": {"text": query},
+                "retriever": {"top_k": top_k, "filters": qdrant_filters},
+            }
+        )
 
         # Extract documents from result
         documents = result.get("retriever", {}).get("documents", [])
@@ -289,9 +302,7 @@ def search(
 # =============================================================================
 
 
-def create_qa_pipeline(
-    store: QdrantDocumentStore, config: OllamaConfig | None = None
-) -> Pipeline:
+def create_qa_pipeline(store: QdrantDocumentStore, config: OllamaConfig | None = None) -> Pipeline:
     """
     Create Haystack Q&A pipeline with LLM generation.
 
@@ -382,11 +393,13 @@ def ask(
         qdrant_filters = build_qdrant_filters(filters)
 
         # Run pipeline
-        result = pipeline.run({
-            "embedder": {"text": question},
-            "retriever": {"top_k": top_k, "filters": qdrant_filters},
-            "prompt_builder": {"query": question},
-        })
+        result = pipeline.run(
+            {
+                "embedder": {"text": question},
+                "retriever": {"top_k": top_k, "filters": qdrant_filters},
+                "prompt_builder": {"query": question},
+            }
+        )
 
         # Extract answer
         replies = result.get("generator", {}).get("replies", [])

--- a/src/rag/stores/__init__.py
+++ b/src/rag/stores/__init__.py
@@ -1,6 +1,7 @@
 """
 RAG Stores - Qdrant Document Store
 """
+
 from src.rag.stores.qdrant import (
     COLLECTION_NAME,
     get_collection_stats,

--- a/src/rag/stores/qdrant.py
+++ b/src/rag/stores/qdrant.py
@@ -1,6 +1,7 @@
 """
 Qdrant Document Store - ベクトルストアのファクトリと管理機能
 """
+
 from __future__ import annotations
 
 from haystack_integrations.document_stores.qdrant import QdrantDocumentStore

--- a/tests/rag/test_config.py
+++ b/tests/rag/test_config.py
@@ -1,6 +1,7 @@
 """
 Tests for RAG Configuration module
 """
+
 import unittest
 from pathlib import Path
 

--- a/tests/rag/test_e2e_indexing.py
+++ b/tests/rag/test_e2e_indexing.py
@@ -4,6 +4,7 @@ E2E Tests for Indexing Pipeline
 Tests the complete indexing flow from vault scanning to document store.
 Uses tempfile for test fixtures and mocks external services.
 """
+
 from __future__ import annotations
 
 import shutil
@@ -324,9 +325,7 @@ class TestE2EIndexingWithJapaneseContent(unittest.TestCase):
         """Clean up."""
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def _create_file(
-        self, filename: str, title: str, content: str, tags: list[str]
-    ) -> None:
+    def _create_file(self, filename: str, title: str, content: str, tags: list[str]) -> None:
         tags_yaml = "\n".join(f"  - {tag}" for tag in tags)
         file_content = f"""---
 title: {title}

--- a/tests/rag/test_e2e_qa.py
+++ b/tests/rag/test_e2e_qa.py
@@ -3,6 +3,7 @@ E2E Tests for Q&A Pipeline
 
 Tests question-answering functionality with mocked Ollama and Qdrant services.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -151,9 +152,7 @@ class TestE2EQA(unittest.TestCase):
 
         self.mock_pipeline.run.return_value = {
             "retriever": {"documents": mock_docs},
-            "generator": {
-                "replies": ["OAuth2は認可フレームワーク、JWTはトークン形式です。"]
-            },
+            "generator": {"replies": ["OAuth2は認可フレームワーク、JWTはトークン形式です。"]},
         }
 
         answer = ask(self.mock_pipeline, "OAuth2とJWTの違いは？")

--- a/tests/rag/test_e2e_search.py
+++ b/tests/rag/test_e2e_search.py
@@ -3,6 +3,7 @@ E2E Tests for Search Pipeline
 
 Tests semantic search functionality with mocked Ollama and Qdrant services.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -123,9 +124,7 @@ class TestE2ESearch(unittest.TestCase):
             ),
         ]
 
-        self.mock_pipeline.run.return_value = {
-            "retriever": {"documents": mock_docs}
-        }
+        self.mock_pipeline.run.return_value = {"retriever": {"documents": mock_docs}}
 
         response = search(self.mock_pipeline, "container orchestration")
 
@@ -146,9 +145,7 @@ class TestE2ESearch(unittest.TestCase):
             position=0,
         )
 
-        self.mock_pipeline.run.return_value = {
-            "retriever": {"documents": [mock_doc]}
-        }
+        self.mock_pipeline.run.return_value = {"retriever": {"documents": [mock_doc]}}
 
         response = search(self.mock_pipeline, "test query")
 
@@ -163,9 +160,7 @@ class TestE2ESearch(unittest.TestCase):
 
     def test_search_with_top_k(self):
         """Search passes top_k to retriever."""
-        self.mock_pipeline.run.return_value = {
-            "retriever": {"documents": []}
-        }
+        self.mock_pipeline.run.return_value = {"retriever": {"documents": []}}
 
         search(self.mock_pipeline, "test", top_k=10)
 
@@ -195,9 +190,7 @@ class TestE2ESearch(unittest.TestCase):
 
     def test_search_no_results(self):
         """Search with no results returns empty response."""
-        self.mock_pipeline.run.return_value = {
-            "retriever": {"documents": []}
-        }
+        self.mock_pipeline.run.return_value = {"retriever": {"documents": []}}
 
         response = search(self.mock_pipeline, "nonexistent topic")
 
@@ -211,9 +204,7 @@ class TestSearchFilters(unittest.TestCase):
     def setUp(self):
         """Set up mock pipeline."""
         self.mock_pipeline = MagicMock()
-        self.mock_pipeline.run.return_value = {
-            "retriever": {"documents": []}
-        }
+        self.mock_pipeline.run.return_value = {"retriever": {"documents": []}}
 
     def test_build_single_vault_filter(self):
         """Single vault filter is built correctly."""
@@ -315,9 +306,7 @@ class TestSearchWithJapaneseQuery(unittest.TestCase):
             "position": 0,
         }
 
-        self.mock_pipeline.run.return_value = {
-            "retriever": {"documents": [mock_doc]}
-        }
+        self.mock_pipeline.run.return_value = {"retriever": {"documents": [mock_doc]}}
 
         response = search(self.mock_pipeline, "コンテナオーケストレーション")
 
@@ -326,9 +315,7 @@ class TestSearchWithJapaneseQuery(unittest.TestCase):
 
     def test_mixed_language_query(self):
         """Mixed ja/en query is handled correctly."""
-        self.mock_pipeline.run.return_value = {
-            "retriever": {"documents": []}
-        }
+        self.mock_pipeline.run.return_value = {"retriever": {"documents": []}}
 
         # Should not raise error
         response = search(self.mock_pipeline, "Kubernetes デプロイメント戦略")
@@ -359,9 +346,7 @@ class TestSearchResultOrdering(unittest.TestCase):
             }
             mock_docs.append(doc)
 
-        self.mock_pipeline.run.return_value = {
-            "retriever": {"documents": mock_docs}
-        }
+        self.mock_pipeline.run.return_value = {"retriever": {"documents": mock_docs}}
 
         response = search(self.mock_pipeline, "test")
 

--- a/tests/rag/test_indexing.py
+++ b/tests/rag/test_indexing.py
@@ -1,6 +1,7 @@
 """
 Tests for Indexing Pipeline - scan_vault, chunk_document, create_indexing_pipeline, index_vault
 """
+
 from __future__ import annotations
 
 import tempfile
@@ -469,7 +470,9 @@ class TestCreateIndexingPipeline(unittest.TestCase):
     @patch("src.rag.pipelines.indexing.Pipeline")
     @patch("src.rag.pipelines.indexing.OllamaDocumentEmbedder")
     @patch("src.rag.pipelines.indexing.DocumentWriter")
-    def test_pipeline_uses_default_config(self, mock_writer_cls, mock_embedder_cls, mock_pipeline_cls):
+    def test_pipeline_uses_default_config(
+        self, mock_writer_cls, mock_embedder_cls, mock_pipeline_cls
+    ):
         """Pipeline uses default config when not provided"""
         mock_store = MagicMock()
 
@@ -483,7 +486,9 @@ class TestCreateIndexingPipeline(unittest.TestCase):
     @patch("src.rag.pipelines.indexing.Pipeline")
     @patch("src.rag.pipelines.indexing.OllamaDocumentEmbedder")
     @patch("src.rag.pipelines.indexing.DocumentWriter")
-    def test_pipeline_connects_components(self, mock_writer_cls, mock_embedder_cls, mock_pipeline_cls):
+    def test_pipeline_connects_components(
+        self, mock_writer_cls, mock_embedder_cls, mock_pipeline_cls
+    ):
         """Pipeline connects embedder to writer"""
         mock_store = MagicMock()
         mock_pipeline = MagicMock()
@@ -564,9 +569,7 @@ Content here.
         )
 
         mock_pipeline = MagicMock()
-        result = index_vault(
-            mock_pipeline, self.vault_path, "test-vault", dry_run=True
-        )
+        result = index_vault(mock_pipeline, self.vault_path, "test-vault", dry_run=True)
 
         self.assertEqual(result.total_docs, 1)
         self.assertEqual(result.indexed_docs, 1)
@@ -587,9 +590,7 @@ Content to be indexed.
         )
 
         mock_pipeline = MagicMock()
-        result = index_vault(
-            mock_pipeline, self.vault_path, "test-vault", dry_run=False
-        )
+        result = index_vault(mock_pipeline, self.vault_path, "test-vault", dry_run=False)
 
         mock_pipeline.run.assert_called_once()
         call_args = mock_pipeline.run.call_args[0][0]
@@ -645,9 +646,7 @@ Skip this.
         )
 
         mock_pipeline = MagicMock()
-        result = index_vault(
-            mock_pipeline, self.vault_path, "test-vault", dry_run=True
-        )
+        result = index_vault(mock_pipeline, self.vault_path, "test-vault", dry_run=True)
 
         self.assertEqual(result.total_docs, 1)
 
@@ -663,9 +662,7 @@ class TestIndexingResult(unittest.TestCase):
     def test_errors_preserved(self):
         """Errors list is preserved"""
         errors = ["Error 1", "Error 2"]
-        result = IndexingResult(
-            total_docs=5, indexed_docs=3, total_chunks=6, errors=errors
-        )
+        result = IndexingResult(total_docs=5, indexed_docs=3, total_chunks=6, errors=errors)
         self.assertEqual(result.errors, errors)
 
 

--- a/tests/rag/test_ollama_client.py
+++ b/tests/rag/test_ollama_client.py
@@ -3,6 +3,7 @@ Tests for Ollama Client module
 
 All HTTP calls are mocked - no running Ollama server required.
 """
+
 import json
 import unittest
 from unittest.mock import MagicMock, patch
@@ -25,9 +26,7 @@ class TestCheckConnection(unittest.TestCase):
 
         self.assertTrue(success)
         self.assertIsNone(error)
-        mock_get.assert_called_once_with(
-            "http://localhost:11434/api/tags", timeout=5
-        )
+        mock_get.assert_called_once_with("http://localhost:11434/api/tags", timeout=5)
 
     @patch("src.rag.clients.ollama.requests.get")
     def test_custom_timeout(self, mock_get):
@@ -40,9 +39,7 @@ class TestCheckConnection(unittest.TestCase):
 
         check_connection("http://localhost:11434", timeout=10)
 
-        mock_get.assert_called_once_with(
-            "http://localhost:11434/api/tags", timeout=10
-        )
+        mock_get.assert_called_once_with("http://localhost:11434/api/tags", timeout=10)
 
     @patch("src.rag.clients.ollama.requests.get")
     def test_timeout_error(self, mock_get):
@@ -103,9 +100,7 @@ class TestGetEmbedding(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.raise_for_status = MagicMock()
-        mock_response.json.return_value = {
-            "embeddings": [[0.1, 0.2, 0.3, 0.4, 0.5]]
-        }
+        mock_response.json.return_value = {"embeddings": [[0.1, 0.2, 0.3, 0.4, 0.5]]}
         mock_post.return_value = mock_response
 
         embedding, error = get_embedding("test text")

--- a/tests/rag/test_performance.py
+++ b/tests/rag/test_performance.py
@@ -10,6 +10,7 @@ Edge Cases:
 - Mixed ja/en document search
 - Search during indexing
 """
+
 from __future__ import annotations
 
 import os

--- a/tests/rag/test_qdrant_store.py
+++ b/tests/rag/test_qdrant_store.py
@@ -3,6 +3,7 @@ Tests for Qdrant Document Store module
 
 All Qdrant operations are mocked - no running Qdrant server required.
 """
+
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/tests/rag/test_query.py
+++ b/tests/rag/test_query.py
@@ -1,6 +1,7 @@
 """
 Tests for Query Pipeline - search, Q&A functionality
 """
+
 from __future__ import annotations
 
 import unittest
@@ -216,9 +217,7 @@ class TestCreateSearchPipeline(unittest.TestCase):
     @patch("src.rag.pipelines.query.Pipeline")
     @patch("src.rag.pipelines.query.OllamaTextEmbedder")
     @patch("src.rag.pipelines.query.QdrantEmbeddingRetriever")
-    def test_pipeline_uses_config(
-        self, mock_retriever_cls, mock_embedder_cls, mock_pipeline_cls
-    ):
+    def test_pipeline_uses_config(self, mock_retriever_cls, mock_embedder_cls, mock_pipeline_cls):
         """Pipeline uses provided config"""
         mock_store = MagicMock()
         config = OllamaConfig(
@@ -272,9 +271,7 @@ class TestCreateSearchPipeline(unittest.TestCase):
     @patch("src.rag.pipelines.query.Pipeline")
     @patch("src.rag.pipelines.query.OllamaTextEmbedder")
     @patch("src.rag.pipelines.query.QdrantEmbeddingRetriever")
-    def test_retriever_uses_store(
-        self, mock_retriever_cls, mock_embedder_cls, mock_pipeline_cls
-    ):
+    def test_retriever_uses_store(self, mock_retriever_cls, mock_embedder_cls, mock_pipeline_cls):
         """Retriever is created with document store"""
         mock_store = MagicMock()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -168,7 +168,9 @@ def _make_claude_zip_bytes(conversations: list[dict]) -> bytes:
     return buf.getvalue()
 
 
-@unittest.skip("E2E test disabled - actual Ollama calls are slow. See Issue #55 for re-enabling plan.")
+@unittest.skip(
+    "E2E test disabled - actual Ollama calls are slow. See Issue #55 for re-enabling plan."
+)
 class TestE2EClaudeImport(unittest.TestCase):
     """E2E test: SequentialRunner with Claude import pipeline (mocked Ollama)."""
 
@@ -244,11 +246,13 @@ class TestE2EClaudeImport(unittest.TestCase):
                 "organized_notes": PartitionedMemoryDataset(),  # Phase 2: renamed from organized_items
                 "organized_items": PartitionedMemoryDataset(),  # Legacy compatibility
                 "review_notes": PartitionedMemoryDataset(),  # Review folder output (final)
-                "parameters": MemoryDataset({
-                    "import": import_params,
-                    "organize": organize_params,
-                    "ollama": ollama_params,
-                }),
+                "parameters": MemoryDataset(
+                    {
+                        "import": import_params,
+                        "organize": organize_params,
+                        "ollama": ollama_params,
+                    }
+                ),
                 "params:import": MemoryDataset(import_params),
                 "params:organize": MemoryDataset(organize_params),
             }
@@ -426,11 +430,13 @@ class TestResumeAfterFailure(unittest.TestCase):
                 "organized_notes": PartitionedMemoryDataset(),
                 "review_notes": PartitionedMemoryDataset(),  # Review folder output (final)
                 "topic_extracted_items": PartitionedMemoryDataset(),
-                "parameters": MemoryDataset({
-                    "import": import_params,
-                    "organize": organize_params,
-                    "ollama": ollama_params,
-                }),
+                "parameters": MemoryDataset(
+                    {
+                        "import": import_params,
+                        "organize": organize_params,
+                        "ollama": ollama_params,
+                    }
+                ),
                 "params:import": MemoryDataset(import_params),
                 "params:organize": MemoryDataset(organize_params),
             }
@@ -697,11 +703,13 @@ class TestPartialRunFromTo(unittest.TestCase):
                 "cleaned_items": PartitionedMemoryDataset(),
                 "organized_notes": PartitionedMemoryDataset(),
                 "review_notes": PartitionedMemoryDataset(),  # Review folder output (final)
-                "parameters": MemoryDataset({
-                    "import": import_params,
-                    "organize": organize_params,
-                    "ollama": ollama_params,
-                }),
+                "parameters": MemoryDataset(
+                    {
+                        "import": import_params,
+                        "organize": organize_params,
+                        "ollama": ollama_params,
+                    }
+                ),
                 "params:import": MemoryDataset(import_params),
                 "params:organize": MemoryDataset(organize_params),
             }
@@ -878,7 +886,9 @@ class OpenAIZipMemoryDataset(AbstractDataset):
         return {"type": "OpenAIZipMemoryDataset"}
 
 
-@unittest.skip("E2E test disabled - actual Ollama calls are slow. See Issue #55 for re-enabling plan.")
+@unittest.skip(
+    "E2E test disabled - actual Ollama calls are slow. See Issue #55 for re-enabling plan."
+)
 class TestE2EOpenAIImport(unittest.TestCase):
     """E2E test: SequentialRunner with OpenAI import pipeline (mocked Ollama).
 
@@ -955,11 +965,13 @@ class TestE2EOpenAIImport(unittest.TestCase):
                 "cleaned_items": PartitionedMemoryDataset(),
                 "organized_notes": PartitionedMemoryDataset(),
                 "review_notes": PartitionedMemoryDataset(),  # Review folder output (final)
-                "parameters": MemoryDataset({
-                    "import": import_params,
-                    "organize": organize_params,
-                    "ollama": ollama_params,
-                }),
+                "parameters": MemoryDataset(
+                    {
+                        "import": import_params,
+                        "organize": organize_params,
+                        "ollama": ollama_params,
+                    }
+                ),
                 "params:import": MemoryDataset(import_params),
                 "params:organize": MemoryDataset(organize_params),
             }


### PR DESCRIPTION
## 概要

lint.yml に ruff format チェックを追加し、コードフォーマットの一貫性を CI で担保する。

## 対応内容

### 1. Makefile 更新
- `format-check` ターゲット追加（`ruff format --check src/ tests/`）
- `format` ターゲット追加（`ruff format src/ tests/`）
- `lint` ターゲットに `format-check` を組み込み

### 2. 既存コードのフォーマット
- `ruff format` で 20 ファイルをフォーマット（空白・改行のみ、意味の変更なし）

### 3. CI 更新
- `.github/workflows/lint.yml` に `format-check` ジョブを追加

## テスト

```bash
make format-check  # ✅ 90 files already formatted
make test          # ✅ 572 tests, OK (skipped=8)
make lint          # ✅ ruff + pylint + format-check passed
```

## 関連 Issue

- Closes #58