### PR TITLE
ci: lint.yml の4ジョブを1ジョブに統合

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  ruff:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,49 +20,4 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
       - run: make setup-dev
-      - run: make ruff
-
-  pylint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Cache venv
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
-      - run: make setup-dev
-      - run: make pylint
-
-  mypy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Cache venv
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
-      - run: make setup-dev
-      - run: make mypy
-
-  format-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Cache venv
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
-      - run: make setup-dev
-      - run: make format-check
+      - run: make lint


### PR DESCRIPTION
## Summary
- lint.yml の4つの独立ジョブ（ruff, pylint, mypy, format-check）を `lint` 1ジョブに統合
- `make lint` が既に全リンターを fail-fast で実行するため、ワークフロー側の重複を解消
- セットアップ（checkout → setup-python → cache → setup-dev）が4回→1回に削減

## Test plan
- [ ] CI が `make lint` で全リンターを正常実行することを確認
- [ ] ruff/pylint/mypy/format-check いずれかが失敗した場合に CI が失敗することを確認

Closes #67