### PR TITLE
feat: デフォルト LLM を GPT-OSS Swallow に変更

### DIFF
--- a/conf/base/parameters.yml
+++ b/conf/base/parameters.yml
@@ -15,7 +15,7 @@ github_clone_dir: ""  # Target directory for git clone (empty = use system temp)
 ollama:
   # Default settings applied to all functions
   defaults:
-    model: "gpt-oss:20b"
+    model: "gpt-oss-swallow:20b"
     base_url: "http://localhost:11434"
     timeout: 120
     warmup_timeout: 300  # Model warmup timeout (seconds) - 20B model needs ~4 min to load
@@ -35,7 +35,7 @@ ollama:
 
     # Topic extraction: very short output (1-3 words)
     extract_topic:
-      model: "gpt-oss:20b"
+      model: "gpt-oss-swallow:20b"
       num_predict: 64
       timeout: 30
 


### PR DESCRIPTION
## Summary
- デフォルト LLM を `gpt-oss:20b` → `gpt-oss-swallow:20b` (GPT-OSS Swallow RL v0.1) に変更
- GPT-OSS Swallow は日本語推論能力が強化されたモデル（日本語知識タスクで +13.0pt 向上）
- Ollama セットアップ済み（HuggingFace GGUF、MXFP4量子化、12GB）

## Test plan
- [x] 全572テスト通過
- [ ] 実際のパイプライン実行で知識抽出品質を確認

Closes #42