### PR TITLE
feat: GPU/CPU フォールバック検知を追加

### DIFF
--- a/src/obsidian_etl/utils/ollama.py
+++ b/src/obsidian_etl/utils/ollama.py
@@ -59,8 +59,69 @@ class OllamaWarmupError(Exception):
         super().__init__(f"Model warmup failed: {model}: {reason}")
 
 
+class OllamaCPUFallbackError(Exception):
+    """Exception raised when model is running on CPU instead of GPU.
+
+    This is a critical error because CPU inference is ~100x slower than GPU,
+    causing pipeline timeouts and poor performance.
+
+    Attributes:
+        model: Model name running on CPU.
+        gpu_percent: Percentage of model loaded on GPU (0 = 100% CPU).
+    """
+
+    def __init__(self, model: str, gpu_percent: float):
+        self.model = model
+        self.gpu_percent = gpu_percent
+        super().__init__(
+            f"CRITICAL: Model '{model}' is running on CPU ({gpu_percent:.0f}% GPU). "
+            "GPU inference required. Check GPU memory with 'nvidia-smi' and "
+            "restart Ollama if needed."
+        )
+
+
 # Track which models have been warmed up
 _warmed_models: set[str] = set()
+
+
+def _check_model_device(model: str, base_url: str) -> tuple[str, float]:
+    """Check if model is loaded on GPU or CPU via /api/ps.
+
+    Args:
+        model: Model name to check.
+        base_url: Ollama server base URL.
+
+    Returns:
+        Tuple of (device_type, gpu_percent).
+        device_type: "GPU", "CPU", "GPU/CPU", or "NOT_LOADED".
+        gpu_percent: Percentage of model on GPU (0-100).
+    """
+    try:
+        url = f"{base_url}/api/ps"
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+
+        for m in data.get("models", []):
+            if m.get("name") == model or m.get("model") == model:
+                size = m.get("size", 0)
+                size_vram = m.get("size_vram", 0)
+
+                if size == 0:
+                    return "UNKNOWN", 0.0
+
+                gpu_percent = (size_vram / size) * 100
+
+                if gpu_percent >= 99.9:
+                    return "GPU", 100.0
+                if gpu_percent <= 0.1:
+                    return "CPU", 0.0
+                return "GPU/CPU", gpu_percent
+
+        return "NOT_LOADED", 0.0
+    except Exception as e:
+        logger.warning(f"Failed to check model device: {e}")
+        return "UNKNOWN", 0.0
 
 
 def _do_warmup(model: str, base_url: str, timeout: int = 30, mock: bool = False) -> None:
@@ -74,6 +135,7 @@ def _do_warmup(model: str, base_url: str, timeout: int = 30, mock: bool = False)
 
     Raises:
         OllamaWarmupError: If warmup fails for any reason.
+        OllamaCPUFallbackError: If model is loaded on CPU instead of GPU.
     """
     if mock:
         logger.info(f"[MOCK] Skipping model warmup: {model}")
@@ -103,6 +165,16 @@ def _do_warmup(model: str, base_url: str, timeout: int = 30, mock: bool = False)
         elapsed = time.time() - start_time
         logger.error(f"Model warmup failed: {model} ({elapsed:.1f}s): {e}")
         raise OllamaWarmupError(model, str(e)) from e
+
+    # Check if model is running on GPU
+    device, gpu_percent = _check_model_device(model, base_url)
+    if device == "CPU":
+        logger.critical(f"Model {model} is running on CPU (0% GPU)")
+        raise OllamaCPUFallbackError(model, gpu_percent)
+    if device == "GPU/CPU":
+        logger.warning(f"Model {model} is partially on GPU ({gpu_percent:.0f}% GPU)")
+    else:
+        logger.info(f"Model {model} device: {device} ({gpu_percent:.0f}% GPU)")
 
 
 def call_ollama(

--- a/tests/utils/test_ollama_warmup.py
+++ b/tests/utils/test_ollama_warmup.py
@@ -139,20 +139,53 @@ class TestDoWarmup(unittest.TestCase):
         """
         from obsidian_etl.utils.ollama import _do_warmup
 
-        # Mock successful response
-        mock_response = MagicMock()
-        mock_response.read.return_value = b'{"message": {"content": "hi"}}'
-        mock_urlopen.return_value.__enter__.return_value = mock_response
+        # Mock responses for warmup (POST /api/chat) and device check (GET /api/ps)
+        mock_warmup_response = MagicMock()
+        mock_warmup_response.read.return_value = b'{"message": {"content": "hi"}}'
+
+        mock_ps_response = MagicMock()
+        mock_ps_response.read.return_value = (
+            b'{"models": [{"name": "gemma3:12b", "size": 1000, "size_vram": 1000}]}'
+        )
+
+        # Return different responses for different calls
+        mock_urlopen.return_value.__enter__.side_effect = [mock_warmup_response, mock_ps_response]
 
         _do_warmup("gemma3:12b", "http://localhost:11434")
 
-        # Verify urlopen was called
-        self.assertEqual(mock_urlopen.call_count, 1)
+        # Verify urlopen was called twice (warmup + device check)
+        self.assertEqual(mock_urlopen.call_count, 2)
 
-        # Verify request payload (minimal request with num_predict=1)
-        request_obj = mock_urlopen.call_args[0][0]
+        # Verify first request (warmup) payload
+        request_obj = mock_urlopen.call_args_list[0][0][0]
         self.assertEqual(request_obj.get_method(), "POST")
         self.assertIn("http://localhost:11434/api/chat", request_obj.full_url)
+
+    @patch("urllib.request.urlopen")
+    def test_warmup_raises_error_on_cpu_fallback(self, mock_urlopen: MagicMock) -> None:
+        """CPU フォールバック時に OllamaCPUFallbackError が発生すること。"""
+        from obsidian_etl.utils.ollama import OllamaCPUFallbackError, _do_warmup
+
+        # Mock responses: warmup succeeds, but device check shows CPU
+        mock_warmup_response = MagicMock()
+        mock_warmup_response.read.return_value = b'{"message": {"content": "hi"}}'
+
+        mock_ps_response = MagicMock()
+        # size_vram = 0 means 100% CPU
+        mock_ps_response.read.return_value = (
+            b'{"models": [{"name": "gemma3:12b", "size": 1000, "size_vram": 0}]}'
+        )
+
+        mock_urlopen.return_value.__enter__.side_effect = [
+            mock_warmup_response,
+            mock_ps_response,
+        ]
+
+        with self.assertRaises(OllamaCPUFallbackError) as ctx:
+            _do_warmup("gemma3:12b", "http://localhost:11434")
+
+        self.assertIn("CPU", str(ctx.exception))
+        self.assertEqual(ctx.exception.gpu_percent, 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

モデルが CPU で実行されている場合、warmup 後に検知して CRITICAL エラーで停止する。

## 背景

GPU メモリ不足などで Ollama がモデルを CPU にフォールバックすると、推論が ~100x 遅くなりタイムアウトが多発する。これを早期に検知してパイプラインを停止する。

## 実装

- `/api/ps` エンドポイントで `size_vram` を確認
- `size_vram == 0` → 100% CPU → `OllamaCPUFallbackError` を発生

```python
class OllamaCPUFallbackError(Exception):
    """Model is running on CPU instead of GPU."""
```

## 検知ロジック

| 状態 | `size_vram` | 動作 |
|------|-------------|------|
| 100% GPU | `size_vram == size` | ✅ 続行 |
| 一部 CPU | `size_vram < size` | ⚠️ WARNING ログ、続行 |
| 100% CPU | `size_vram == 0` | ❌ CRITICAL、停止 |

## Test plan

- [x] `make test` - 598 tests passed
- [x] `make lint` - All linters passed
- [x] CPU フォールバック時のエラー発生テスト追加

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)