### PR TITLE
feat: review ファイルの再処理用 Makefile ターゲットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ export KEDRO_LOGGING_CONFIG := $(BASE_DIR)/conf/base/logging.yml
 .PHONY: test-golden-responses test-integration test-clean
 .PHONY: coverage check lint ruff pylint mypy format format-check clean
 .PHONY: rag-index rag-search rag-ask rag-status vault-preview vault-copy
+.PHONY: reprocess-review
 .PHONY: _check-ollama
 
 all: help
@@ -48,6 +49,9 @@ kedro-run:
 
 kedro-viz: ##@ DAG 可視化
 	@cd $(BASE_DIR) && $(PYTHON) -m kedro viz
+
+reprocess-review: ##@ review ファイルを削除して再処理対象に戻す
+	@bash scripts/makefile/reprocess-review.sh
 
 # ── Test Fixtures ─────────────────────────────────────────
 

--- a/scripts/makefile/reprocess-review.sh
+++ b/scripts/makefile/reprocess-review.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+REVIEW_DIR="${BASE_DIR}/data/04_feature/review"
+KNOWLEDGE_DIR="${BASE_DIR}/data/03_primary/transformed_knowledge"
+
+if [ ! -d "$REVIEW_DIR" ] || [ -z "$(ls -A "$REVIEW_DIR" 2>/dev/null)" ]; then
+    echo "No review files found in ${REVIEW_DIR}"
+    exit 0
+fi
+
+count=0
+for md in "$REVIEW_DIR"/*.md; do
+    [ -f "$md" ] || continue
+
+    file_id=$(grep '^file_id:' "$md" | sed 's/^file_id: *//')
+    if [ -z "$file_id" ]; then
+        echo "WARN: file_id not found in $(basename "$md"), skipping"
+        continue
+    fi
+
+    json_path="${KNOWLEDGE_DIR}/${file_id}.json"
+    if [ -f "$json_path" ]; then
+        rm -f "$json_path"
+        echo "  Deleted: $(basename "$json_path")"
+    fi
+
+    rm -f "$md"
+    echo "  Deleted: $(basename "$md")"
+    count=$((count + 1))
+done
+
+echo ""
+echo "Cleared ${count} review files and corresponding intermediate data."
+echo "Run 'make run' to reprocess."


### PR DESCRIPTION
## Summary
- `make reprocess-review` ターゲットを追加
- review ファイルから `file_id` を取得し、`04_feature/review/` と `03_primary/transformed_knowledge/` の対応ファイルを削除
- 削除後 `make run` で再処理される（`overwrite: false` により削除分のみ対象）

## 使い方
```bash
make reprocess-review   # review ファイルと中間データを削除
make run                # 削除分だけ再処理
```

Closes #93

## Test plan
- [ ] review ファイルが存在する状態で `make reprocess-review` を実行し、ファイルが削除されることを確認
- [ ] 削除後 `make run` で該当会話が再処理されることを確認
- [ ] review ファイルが空の場合にエラーなく終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)