### PR TITLE
feat: チャンク分けを chunk_enabled フラグで制御

### DIFF
--- a/src/obsidian_etl/pipelines/extract_claude/nodes.py
+++ b/src/obsidian_etl/pipelines/extract_claude/nodes.py
@@ -23,6 +23,7 @@ MIN_CONTENT_LENGTH = 10  # Minimum content length after processing
 def parse_claude_json(
     conversations: list[dict[str, Any]],
     existing_output: dict[str, Callable[..., Any]] | None = None,
+    params: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Parse Claude export JSON conversations to ParsedItem format.
 
@@ -30,6 +31,7 @@ def parse_claude_json(
         conversations: List of Claude conversation dicts from conversations.json.
         existing_output: DEPRECATED - not used. Parse always processes all conversations.
                         Transform nodes handle resume logic instead.
+        params: Import parameters from parameters.yml.
 
     Returns:
         Dict mapping partition_id (file_id or file_id_chunkN) to ParsedItem dict.
@@ -101,7 +103,8 @@ def parse_claude_json(
         file_id = generate_file_id(content, virtual_path)
 
         # Check if chunking needed
-        if should_chunk(normalized_messages):
+        chunk_enabled = (params or {}).get("chunk_enabled", False)
+        if chunk_enabled and should_chunk(normalized_messages):
             # Chunk and create multiple ParsedItems
             chunks = split_messages(normalized_messages)
             parent_item_id = file_id
@@ -210,6 +213,7 @@ def _fallback_conversation_name(messages: list[dict[str, Any]]) -> str:
 def parse_claude_zip(
     partitioned_input: dict[str, Callable[..., Any]],
     existing_output: dict[str, Callable[..., Any]] | None = None,
+    params: dict[str, Any] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Parse Claude export ZIP to ParsedItem format.
 
@@ -220,6 +224,7 @@ def parse_claude_zip(
         partitioned_input: Dict of filename -> Callable returning ZIP bytes.
         existing_output: DEPRECATED - not used. Parse always processes all conversations.
                         Transform nodes handle resume logic instead.
+        params: Import parameters from parameters.yml.
 
     Returns:
         Dict mapping partition_id (file_id or file_id_chunkN) to ParsedItem dict.
@@ -265,7 +270,7 @@ def parse_claude_zip(
             continue
 
         # Use existing parse_claude_json logic to process conversations
-        parsed_from_zip = parse_claude_json(conversations_data, existing_output=None)
+        parsed_from_zip = parse_claude_json(conversations_data, existing_output=None, params=params)
 
         # Merge into result
         result.update(parsed_from_zip)

--- a/src/obsidian_etl/pipelines/extract_claude/pipeline.py
+++ b/src/obsidian_etl/pipelines/extract_claude/pipeline.py
@@ -31,7 +31,10 @@ def create_pipeline(**kwargs: Any) -> Pipeline:
         [
             node(
                 func=parse_claude_zip,
-                inputs="raw_claude_conversations",
+                inputs={
+                    "partitioned_input": "raw_claude_conversations",
+                    "params": "params:import",
+                },
                 outputs="parsed_items",
                 name="parse_claude_zip",
             ),

--- a/src/obsidian_etl/pipelines/extract_openai/nodes.py
+++ b/src/obsidian_etl/pipelines/extract_openai/nodes.py
@@ -116,7 +116,8 @@ def parse_chatgpt_zip(
             file_id = generate_file_id(content, virtual_path)
 
             # Check if chunking needed
-            if should_chunk(messages):
+            chunk_enabled = (params or {}).get("chunk_enabled", False)
+            if chunk_enabled and should_chunk(messages):
                 # Chunk and create multiple ParsedItems
                 chunks = split_messages(messages)
                 parent_item_id = file_id

--- a/tests/pipelines/extract_claude/test_nodes.py
+++ b/tests/pipelines/extract_claude/test_nodes.py
@@ -109,7 +109,7 @@ class TestParseCaudeJsonChunking(unittest.TestCase):
     """parse_claude_json: 25000+ char conversation -> multiple chunks."""
 
     def test_parse_claude_json_chunking(self):
-        """25000文字以上の会話が複数チャンクに分割されること。"""
+        """25000文字以上の会話が chunk_enabled=True で複数チャンクに分割されること。"""
         # Create a conversation with messages exceeding 25000 chars
         long_text = "A" * 13000  # Each message ~13000 chars -> total ~26000
         conversations = [
@@ -147,7 +147,7 @@ class TestParseCaudeJsonChunking(unittest.TestCase):
             }
         ]
 
-        result = parse_claude_json(conversations)
+        result = parse_claude_json(conversations, params={"chunk_enabled": True})
 
         # Should produce multiple chunks
         self.assertGreater(len(result), 1)

--- a/tests/pipelines/extract_openai/test_nodes.py
+++ b/tests/pipelines/extract_openai/test_nodes.py
@@ -777,7 +777,7 @@ class TestChatgptChunking(unittest.TestCase):
 
         zip_bytes = _make_zip_bytes([conv])
         partitioned = _make_partitioned_input({"test.zip": zip_bytes})
-        result = parse_chatgpt_zip(partitioned)
+        result = parse_chatgpt_zip(partitioned, params={"chunk_enabled": True})
 
         # Should produce multiple chunks
         self.assertGreater(len(result), 1)
@@ -809,7 +809,7 @@ class TestChatgptChunking(unittest.TestCase):
 
         zip_bytes = _make_zip_bytes([conv])
         partitioned = _make_partitioned_input({"test.zip": zip_bytes})
-        result = parse_chatgpt_zip(partitioned)
+        result = parse_chatgpt_zip(partitioned, params={"chunk_enabled": True})
 
         items = list(result.values())
         for item in items:
@@ -846,7 +846,7 @@ class TestChatgptChunking(unittest.TestCase):
 
         zip_bytes = _make_zip_bytes([conv])
         partitioned = _make_partitioned_input({"test.zip": zip_bytes})
-        result = parse_chatgpt_zip(partitioned)
+        result = parse_chatgpt_zip(partitioned, params={"chunk_enabled": True})
 
         items = list(result.values())
         chunk_indices = sorted(item["chunk_index"] for item in items)
@@ -879,7 +879,7 @@ class TestChatgptChunking(unittest.TestCase):
 
         zip_bytes = _make_zip_bytes([conv])
         partitioned = _make_partitioned_input({"test.zip": zip_bytes})
-        result = parse_chatgpt_zip(partitioned)
+        result = parse_chatgpt_zip(partitioned, params={"chunk_enabled": True})
 
         items = list(result.values())
         parent_ids = {item["parent_item_id"] for item in items}
@@ -912,7 +912,7 @@ class TestChatgptChunking(unittest.TestCase):
 
         zip_bytes = _make_zip_bytes([conv])
         partitioned = _make_partitioned_input({"test.zip": zip_bytes})
-        result = parse_chatgpt_zip(partitioned)
+        result = parse_chatgpt_zip(partitioned, params={"chunk_enabled": True})
 
         for item in result.values():
             self.assertEqual(item["source_provider"], "openai")


### PR DESCRIPTION
## Summary
- `parameters.yml` の `import.chunk_enabled` フラグでチャンク分割を制御可能にした
- デフォルト `false`（無効）により、大きな会話も分割せず単一アイテムとして処理
- 既存チャンクテストは `chunk_enabled=True` を明示的に渡すよう修正

## Test plan
- [x] `make test` — 602 tests passed
- [x] `make lint` — all checks passed
- [x] `make test-integration` — passed

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)