### PR TITLE
docs: データ永続性・RAG連携の文書化とrsync同期スクリプト追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,51 @@ kedro run --to-nodes=format_markdown
 
 ```
 data/01_raw/*.zip → data/02_intermediate/parsed/*.json
-                  → data/03_primary/transformed/*.json
+                  → data/03_primary/transformed_knowledge/*.json
+                  → data/03_primary/transformed_metadata/*.json
                   → data/04_feature/notes/*.md
                   → data/05_model_input/classified/*.json
                   → data/05_model_input/normalized/*.json
                   → data/07_model_output/organized/*.md
 ```
+
+### データ永続性
+
+全レイヤーの PartitionedDataset は `overwrite: false` で設定されており、パイプライン再実行時に既存ファイルは上書きされない。
+
+| レイヤー | パス | 永続性 | 命名規則 |
+|---------|------|--------|---------|
+| 01_raw | `data/01_raw/{provider}/*.zip` | 手動管理（削除しない） | 入力ファイル名 |
+| 02_intermediate | `data/02_intermediate/parsed/*.json` | 永続（`overwrite: false`） | `{file_id}.json` |
+| 03_primary | `data/03_primary/transformed_knowledge/*.json` | 永続（`overwrite: false` + streaming） | `{file_id}.json` |
+| 04_feature | `data/04_feature/notes/*.md`, `review/*.md` | 永続 | `{sanitized_title}.md` |
+| 05_model_input | `data/05_model_input/*/*.json` | 永続 | `{file_id}.json` |
+| 07_model_output | `data/07_model_output/organized/*.md` | 永続 | `{sanitized_title}.md` |
+
+`file_id` は `SHA256(content, source_path)` の先頭 12 hex chars。決定論的でデデュプ可能。
+
+### RAG 連携（knowledge-rag）
+
+RAG システム（[knowledge-rag](https://github.com/rengotaku/knowledge-rag)）へのデータ転送対象:
+
+```
+rsync 対象: data/03_primary/transformed_knowledge/
+```
+
+`transformed_knowledge/*.json` には以下が含まれており、RAG に必要な全データが 1 ファイルに集約されている:
+
+| フィールド | RAG での役割 |
+|-----------|-------------|
+| `content` | 原文（精密検索用チャンク化ソース） |
+| `messages` | 構造化された会話ログ（role/content ペア） |
+| `generated_metadata.summary` | 粗い検索のインデックス |
+| `generated_metadata.summary_content` | 要約本文（コンテキスト提供） |
+| `generated_metadata.title` | 検索結果の表示・識別 |
+| `generated_metadata.tags` | カテゴリフィルタ |
+| `file_id` | 一意識別子 |
+| `created_at` | 時系列フィルタ |
+
+`02_intermediate/parsed/` の別途転送は不要（`03_primary` に原文が含まれるため）。
 
 ### プロバイダー別処理
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export KEDRO_LOGGING_CONFIG := $(BASE_DIR)/conf/base/logging.yml
 .PHONY: test test-fixtures test-e2e test-e2e-update-golden test-e2e-golden
 .PHONY: test-golden-responses test-integration test-clean
 .PHONY: coverage check lint ruff pylint mypy format format-check clean
-.PHONY: rag-index rag-search rag-ask rag-status vault-preview vault-copy
+.PHONY: rag-index rag-search rag-ask rag-status vault-preview vault-copy sync-to-rag
 .PHONY: reprocess-review reprocess-review-claude
 .PHONY: _check-ollama
 
@@ -148,6 +148,9 @@ rag-status: ##@ RAG インデックス状態表示
 	@cd $(BASE_DIR) && $(PYTHON) -m src.rag.cli status $(if $(FORMAT),--format $(FORMAT),)
 
 # ── Vault Output ──────────────────────────────────────────
+
+sync-to-rag: ##@ RAG サーバーへデータ同期 [RAG_HOST=xxx] [DRY_RUN=1]
+	@bash scripts/sync-to-rag.sh
 
 vault-preview: ##@ Vault 出力先プレビュー（dry-run）
 	@cd $(BASE_DIR) && kedro run --pipeline=organize_preview

--- a/scripts/sync-to-rag.sh
+++ b/scripts/sync-to-rag.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# RAG システム (knowledge-rag) へのデータ同期スクリプト
+#
+# 使用方法:
+#   ./scripts/sync-to-rag.sh                          # デフォルト設定で同期
+#   RAG_HOST=192.168.1.100 ./scripts/sync-to-rag.sh   # ホスト指定
+#   DRY_RUN=1 ./scripts/sync-to-rag.sh                # ドライラン
+#
+# 環境変数:
+#   RAG_HOST      - RAG マシンのホスト名/IP (デフォルト: rag-server)
+#   RAG_USER      - SSH ユーザー (デフォルト: 現在のユーザー)
+#   RAG_DATA_DIR  - RAG 側のデータディレクトリ (デフォルト: ~/knowledge-rag/data/source)
+#   DRY_RUN       - 1 でドライラン (デフォルト: 0)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+RAG_HOST="${RAG_HOST:-rag-server}"
+RAG_USER="${RAG_USER:-$(whoami)}"
+RAG_DATA_DIR="${RAG_DATA_DIR:-~/knowledge-rag/data/source}"
+DRY_RUN="${DRY_RUN:-0}"
+
+SOURCE_DIR="${PROJECT_DIR}/data/03_primary/transformed_knowledge/"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "ERROR: Source directory not found: $SOURCE_DIR" >&2
+    exit 1
+fi
+
+FILE_COUNT=$(find "$SOURCE_DIR" -name '*.json' | wc -l)
+echo "Syncing ${FILE_COUNT} files from transformed_knowledge/ to ${RAG_USER}@${RAG_HOST}:${RAG_DATA_DIR}"
+
+RSYNC_OPTS=(
+    -avz
+    --include='*.json'
+    --exclude='*'
+    --progress
+)
+
+if [ "$DRY_RUN" = "1" ]; then
+    RSYNC_OPTS+=(--dry-run)
+    echo "(dry-run mode)"
+fi
+
+rsync "${RSYNC_OPTS[@]}" \
+    "$SOURCE_DIR" \
+    "${RAG_USER}@${RAG_HOST}:${RAG_DATA_DIR}/"
+
+echo "Done."


### PR DESCRIPTION
## Summary

- CLAUDE.md にデータ永続性セクションを追加（全レイヤー `overwrite: false` の挙動を明文化）
- RAG 連携セクションを追加（転送対象は `03_primary/transformed_knowledge/` のみで、原文+要約+メタデータが全て含まれる）
- rsync 同期スクリプト `scripts/sync-to-rag.sh` を追加
- Makefile に `sync-to-rag` ターゲットを追加

## 背景

#107 の調査で以下が判明:
- `02_intermediate` は既に `overwrite: false` で永続化されており追加実装不要
- `03_primary/transformed_knowledge/` に原文（`content`, `messages`）も含まれているため、このディレクトリだけ rsync すれば RAG に必要な全データが揃う

## Test plan

- [x] `make test` 全テスト通過（622件）
- [x] `make lint` 通過（ruff + pylint + mypy + format-check）
- [ ] `make sync-to-rag DRY_RUN=1` でドライラン確認（RAG マシン接続時）

Closes #106
Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)